### PR TITLE
Add `raw` property to sheet models.

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -247,6 +247,7 @@
     this.column_names = [];
     this.name = options.data.feed.title.$t;
     this.elements = [];
+    this.raw = options.data; // A copy of the sheet's raw data, for accessing minutiae
 
     for(var key in options.data.feed.entry[0]){
       if(/^gsx/.test(key))


### PR DESCRIPTION
Allows for access to minutiae, such as the time a sheet was last updated. Let me know if you'd rather call the property something else, and I'd happily rewrite.

p.s., Used Tabletop for the first time this week, and loved it. Thanks!
