### PR TITLE
Replace alert() with this.log().

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -51,7 +51,7 @@
     }
 
     if(!this.key) {
-      alert("You need to pass Tabletop a key!");
+      this.log("You need to pass Tabletop a key!");
       return;
     }
 
@@ -76,7 +76,7 @@
   };
 
   Tabletop.sheets = function() {
-    alert("Times have changed! You'll want to use var tabletop = Tabletop.init(...); tabletop.sheets(...); instead of Tabletop.sheets(...)");
+    this.log("Times have changed! You'll want to use var tabletop = Tabletop.init(...); tabletop.sheets(...); instead of Tabletop.sheets(...)");
   };
 
   Tabletop.prototype = {


### PR DESCRIPTION
I have an event on an input triggered on keyup to initialize a Tabletop object. When the input is deleted, Tabletop pops up it's alert. While alert is fine for local debugging, I don't think it should be used in a deployment.
