### PR TITLE
Adding in proxyPrefix option.

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -54,6 +54,10 @@
       this.singleton = true;
     }
     
+    // The proxyPrefix allows for a proxy of type 
+    // http://example.com/proxy?url=http://originalrequest.com
+    this.proxyPrefix = options.proxyPrefix || false;
+    
     if(this.singleton) {
       if(typeof(Tabletop.singleton) !== 'undefined') {
         this.log("WARNING! Tabletop singleton already defined");
@@ -148,6 +152,11 @@
         }
       } else {
         script.src = this.endpoint + url;
+      }
+      
+      // Handle a proxy prefix
+      if (this.proxyPrefix) {
+        script.src = this.proxyPrefix + encodeURIComponent(script.src);
       }
       
       document.getElementsByTagName('script')[0].parentNode.appendChild(script);


### PR DESCRIPTION
This options allows for a different type of proxy, one that is server based and handles the original URL as a query parameter.

My use case is that I built a simple, caching proxy for Google spreadsheets requests for use with Tabletop:
https://github.com/MinnPost/gs-proxy

I am not sure if proxyPrefix is the best option name given that there is already a proxy parameter, but didn't want to change any existing behavior.

Thanks for the great work on Tabletop.

Sidenote: It's interesting that you were working on Flatware at pretty much the same time as I was working on gs-proxy.  They both try to solve the same problem but their paradigms are a bit different.
