### PR TITLE
Changing helper indexOf to use standalone function

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -213,7 +213,7 @@
       if(this.simple_url) {
         // We've gone down a rabbit hole of passing injectScript the path, so let's
         // just pull the sheet_id out of the path like the least efficient worker bees
-        if(ttIndexOf(path, "/list/") !== -1) {
+        if(path.indexOf("/list/") !== -1) {
           script.src = this.endpoint + "/" + this.key + "-" + path.split("/")[4];
         } else {
           script.src = this.endpoint + "/" + this.key;


### PR DESCRIPTION
Changing helper indexOf to use standalone function so that older browsers will not find in for loops and break bad code.  This is basically how underscore.js does this.

When you extend the prototype, which is in theory they correct way, you can create problems in older browsers (like IE8).

For instance, if you run this on an array, after including Tabletop.js

```
for (var i in anArray) {
  console.log(i);
}
```

This will output all the values, plus the `indexOf` function.

The proper way to write for loops in this situation is using the `hasOwnProperty` to ensure you do not loop over prototypal values.

```
for (var i in anArray) {
  if (anArray.hasOwnProperty(i)) { console.log(i); }
}
```

Unfortunately in my situation, there is already code that is using the bad version of loops on the page that I don't have the ability to edit.

See:
http://underscorejs.org/docs/underscore.html#section-54
http://api.jquery.com/jQuery.inArray/
