### PR TITLE
Improved node interface.

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -31,7 +31,7 @@
     Initialize with Tabletop.init('0AjAPaAU9MeLFdHUxTlJiVVRYNGRJQnRmSnQwTlpoUXc')
   */
 
-  var Tabletop = global.Tabletop = function(options) {
+  var Tabletop = function(options) {
     // Make sure Tabletop is being used as a constructor no matter what.
     if(!this || !(this instanceof Tabletop)) {
       return new Tabletop(options);
@@ -404,4 +404,10 @@
     }
   };
 
-})(typeof process === 'undefined' ? this : module.exports);
+  if(inNodeJS) {
+    module.exports = Tabletop;
+  } else {
+    global.Tabletop = Tabletop;
+  }
+
+})(this);


### PR DESCRIPTION
Tabletop is now exported directly from `require('tabletop')`, instead of being the only property of the export. I think this is the expected behavior of a node module (and, given the lack of documentation on the node side, probably it's worth changing, unless there's a compelling reason I haven't thought of to keep it as a property).
