### PR TITLE
Changed sheetid delimiters to pipes

### DIFF
--- a/caching/local.rb
+++ b/caching/local.rb
@@ -20,7 +20,7 @@ sheet_ids = base_json_content.scan(/\/public\/basic\/(\w*)/).flatten.uniq
 sheet_ids.each do |sheet_id|
   sheet_url = "https://spreadsheets.google.com//feeds/list/#{key}/#{sheet_id}/public/values?alt=json-in-script&sq=&callback=Tabletop.singleton.loadSheet"
   content = open(sheet_url).read
-  File.open("#{key}-#{sheet_id}", 'w') { |f| f.write(content) } 
+  File.open("#{key}|#{sheet_id}", 'w') { |f| f.write(content) } 
 end
 
 File.open("#{key}", 'w') { |f| f.write(base_json_content) } 

--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -169,7 +169,7 @@
         // We've gone down a rabbit hole of passing injectScript the path, so let's
         // just pull the sheet_id out of the path like the least efficient worker bees
         if(path.indexOf("/list/") !== -1) {
-          script.src = this.endpoint + "/" + this.key + "-" + path.split("/")[4];
+          script.src = this.endpoint + "/" + this.key + "|" + path.split("/")[4];
         } else {
           script.src = this.endpoint + "/" + this.key;
         }


### PR DESCRIPTION
Google Spreadsheet keys can contain dashes, so they're a problematic character to use as a delimiter between keys and sheetids. Pipes seem a safer choice (although there's maybe an even better choice I've not considered?)
