### PR TITLE
Fixed tabletop error in IE8

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -7,22 +7,38 @@
     var request = require('request');
   }
 
+  // from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
   if (!Array.prototype.indexOf) {
-    Array.prototype.indexOf = function (obj, fromIndex) {
-      if (fromIndex === null) {
-          fromIndex = 0;
-      } else if (fromIndex < 0) {
-          fromIndex = Math.max(0, this.length + fromIndex);
+    Array.prototype.indexOf = function (searchElement /*, fromIndex */ ) {
+      if (this == null) {
+        throw new TypeError();
       }
-      for (var i = fromIndex, j = this.length; i < j; i++) {
-          if (this[i] === obj) {
-              return i;
-          }
+      var t = Object(this);
+      var len = t.length >>> 0;
+      if (len === 0) {
+        return -1;
+      }
+      var n = 0;
+      if (arguments.length > 1) {
+        n = Number(arguments[1]);
+        if (n != n) { // shortcut for verifying if it's NaN
+          n = 0;
+        } else if (n != 0 && n != Infinity && n != -Infinity) {
+          n = (n > 0 || -1) * Math.floor(Math.abs(n));
+        }
+      }
+      if (n >= len) {
+        return -1;
+      }
+      var k = n >= 0 ? n : Math.max(len - Math.abs(n), 0);
+      for (; k < len; k++) {
+        if (k in t && t[k] === searchElement) {
+          return k;
+        }
       }
       return -1;
-    };
+    }
   }
-  
   /*
     Initialize with Tabletop.init( { key: '0AjAPaAU9MeLFdHUxTlJiVVRYNGRJQnRmSnQwTlpoUXc' } )
       OR!


### PR DESCRIPTION
The old polyfill for indexOf was not working in IE8 (returned -1 for values that were in the array). This version (copied from the Mozilla docs) works correctly.
