### PR TITLE
added bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "tabletop",
+  "version": "1.3.2",
+  "homepage": "https://github.com/jsoma/tabletop",
+  "authors": [
+    "\"\""
+  ],
+  "description": "**Tabletop.js** takes a Google Spreadsheet and makes it easily accessible through JavaScript. With zero dependencies!",
+  "main": "src/tabletop.js",
+  "keywords": [
+    "table",
+    "sql",
+    "spreadsheet"
+  ],
+  "license": "BSD",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Since tabletop.js can be easily used in the browser, it would be nice to see it as a listed package in Bower (broser based package manager). Here's a bower.json file which probably gets the job done. After this, it's just a matter of following the instructions from here: http://bower.io/#registering-packages
