### PR TITLE
Use CORS to request sheets in compatible browsers.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,23 @@
+module.exports = function(grunt) {
+
+    grunt.loadNpmTasks("grunt-contrib-connect");
+
+    grunt.initConfig({
+        connect: {
+            testing: {
+                options: {
+                    port: 8080
+                }
+            },
+            secure: {
+                options: {
+                    port: 8081,
+                    keepalive: true,
+                    protocol: "https"
+                }
+            }
+        }
+    });
+
+    grunt.registerTask("default", ["connect"]);
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "readmeFilename": "README.md",
   "gitHead": "fdb1c3ee3bc0f7f3be6ab223a56f9f050fe32496",
   "dependencies": {
-    "request": "~2.16.6"
+    "request": "~2.16.6",
+    "grunt": "*",
+    "grunt-contrib-connect": "*"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This change will allow Tabletop to pull from Google using the JSON feed instead of JSONP in browsers that support cross-origin XHR. It will work in Firefox and Chrome, and should work in IE8/9 -- with one caveat: Internet Explorer's XDomainRequest object will not make requests across protocols, so the page hosting Tabletop must be served via HTTPS in order to talk to Google's HTTPS endpoint. Otherwise, you're back to proxies.

On the other hand, this is also much cleaner in browsers that support CORS fully, and should be more secure.

I also added a Gruntfile and a task to run servers on both https and http for testing in browsers. The package.json updates are not very specific, but these are pretty stable modules.
