### PR TITLE
Feature node js detection fix

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -2,7 +2,7 @@
   "use strict";
 
   var inNodeJS = false;
-  if (typeof module !== 'undefined' && module.exports) {
+  if (typeof window === 'undefined' && typeof module !== 'undefined' && module.exports) {
     inNodeJS = true;
     var request = require('request');
   }


### PR DESCRIPTION
I ran into an instance where `process` got defined for some reason and so this updated the NodeJS check to use `exports` as well as checks that there is not a `window` either.

Not really sure what is the most preferred way to check, but got some inspiration from Underscore:
http://underscorejs.org/docs/underscore.html#section-10
