### PR TITLE
Don't include empty query parameter in URLs

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -310,11 +310,14 @@
         // Only pull in desired sheets to reduce loading
         if( this.isWanted(data.feed.entry[i].content.$t) ) {
           var sheet_id = data.feed.entry[i].link[3].href.substr( data.feed.entry[i].link[3].href.length - 3, 3);
-          var json_path = "/feeds/list/" + this.key + "/" + sheet_id + "/public/values?sq=" + this.query + '&alt='
+          var json_path = "/feeds/list/" + this.key + "/" + sheet_id + "/public/values?alt="
           if (inNodeJS || supportsCORS) {
             json_path += 'json';
           } else {
             json_path += 'json-in-script';
+          }
+          if(this.query) {
+            json_path += "&sq=" + this.query;
           }
           if(this.orderby) {
             json_path += "&orderby=column:" + this.orderby.toLowerCase();


### PR DESCRIPTION
The spreadsheets API endpoint returns an HTTP 400 error with a
message of "Invalid query parameter value for sq." when the
`sq` query parameter is empty.  The default case for Tabletop
is an empty query.  Only add the `sq` parameter to the generated
URL if `this.query` is not empty.

Addresses https://github.com/jsoma/tabletop/issues/45
