### PR TITLE
More graceful match for old google url

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -92,7 +92,7 @@
     /* Be friendly about what you accept */
     if(/key=/.test(this.key)) {
       this.log("You passed an old Google Docs url as the key! Attempting to parse.");
-      this.key = this.key.match("key=(.*?)&")[1];
+      this.key = this.key.match("key=(.*?)(&|#|$)")[1];
     }
 
     if(/pubhtml/.test(this.key)) {


### PR DESCRIPTION
spreadsheet key can be followed by hash or nothing.
