### PR TITLE
Fix to allow use with new version of Google Sheets

### DIFF
--- a/caching/local.rb
+++ b/caching/local.rb
@@ -1,13 +1,17 @@
 #####
 # Run as 
-# ruby local.rb "https://docs.google.com/spreadsheet/pub?hl=en_US&hl=en_US&key=0AmYzu_s7QHsmdE5OcDE1SENpT1g2R2JEX2tnZ3ZIWHc&output=html"
-######
+# ruby local.rb "https://docs.google.com/spreadsheets/d/0AmYzu_s7QHsmdE5OcDE1SENpT1g2R2JEX2tnZ3ZIWHc/pubhtml"
+# You will need to have shared the spreadsheet as well as publishing it; "link only" is fine.
+# If certificate errors, follow the instructions here to download a cacert.pem
+#####
 
 require 'open-uri'
 require 'json'
+require 'uri'
 
 dirty_key = ARGV[0]
-key = dirty_key.gsub(/.*key=(.*?)\&.*/,'\1')
+uri_parsed = URI.split(dirty_key)[5]
+key = uri_parsed.split('/')[3]
 
 puts key
 
@@ -18,7 +22,7 @@ base_json_content = open(base_json_url).read
 sheet_ids = base_json_content.scan(/\/public\/basic\/(\w*)/).flatten.uniq
 
 sheet_ids.each do |sheet_id|
-  sheet_url = "https://spreadsheets.google.com//feeds/list/#{key}/#{sheet_id}/public/values?alt=json-in-script&sq=&callback=Tabletop.singleton.loadSheet"
+  sheet_url = "https://spreadsheets.google.com/feeds/list/#{key}/#{sheet_id}/public/values?alt=json-in-script&callback=Tabletop.singleton.loadSheet"
   content = open(sheet_url).read
   File.open("#{key}-#{sheet_id}", 'w') { |f| f.write(content) } 
 end


### PR DESCRIPTION
Now that pretty much everyone had moved over, or been moved over to the new Google Sheets, the URI reference given when a sheet is published has changed. This seems to work fine for me on sheets using the new version.
Also there was a double // in the original URL, and a pointless &sq= which broke things.
Ruby newbie, so apologies if code is rusty.
