### PR TITLE
Adds an "--old" flag to local.py and local.rb. Fixes #67.

### DIFF
--- a/caching/local.py
+++ b/caching/local.py
@@ -12,6 +12,11 @@ import json
 
 key = sys.argv[1]
 
+if '--old' in sys.argv:
+    sq = "&sq="
+else:
+    sq = ""
+
 base_json_url = "https://spreadsheets.google.com/feeds/worksheets/"+key+"/public/basic?alt=json-in-script&callback=Tabletop.singleton.loadSheets"
 
 base_json_content = urllib2.urlopen(base_json_url).read()
@@ -19,10 +24,10 @@ base_json_content = urllib2.urlopen(base_json_url).read()
 sheet_ids = set(re.findall(r"/public/basic/(\w*)",base_json_content, flags=0))
 
 for sheet_id in sheet_ids:
-  sheet_url = "https://spreadsheets.google.com//feeds/list/"+key+"/"+sheet_id+"/public/values?alt=json-in-script&sq=&callback=Tabletop.singleton.loadSheet"
+  sheet_url = "https://spreadsheets.google.com/feeds/list/"+key+"/"+sheet_id+"/public/values?alt=json-in-script" + sq + "&callback=Tabletop.singleton.loadSheet"
   content = urllib2.urlopen(sheet_url).read()
   with open(key+"-"+sheet_id, "w") as f:
 		f.write(content)
-		
+
 with open(key, "w") as f:
 	f.write(base_json_content)

--- a/caching/local.rb
+++ b/caching/local.rb
@@ -1,5 +1,5 @@
 #####
-# Run as 
+# Run as
 # ruby local.rb "https://docs.google.com/spreadsheet/pub?hl=en_US&hl=en_US&key=0AmYzu_s7QHsmdE5OcDE1SENpT1g2R2JEX2tnZ3ZIWHc&output=html"
 ######
 
@@ -8,6 +8,12 @@ require 'json'
 
 dirty_key = ARGV[0]
 key = dirty_key.gsub(/.*key=(.*?)\&.*/,'\1')
+
+if ARGV.include? "--old"
+  sq = "&sq="
+else
+  sq = ""
+end
 
 puts key
 
@@ -18,9 +24,9 @@ base_json_content = open(base_json_url).read
 sheet_ids = base_json_content.scan(/\/public\/basic\/(\w*)/).flatten.uniq
 
 sheet_ids.each do |sheet_id|
-  sheet_url = "https://spreadsheets.google.com//feeds/list/#{key}/#{sheet_id}/public/values?alt=json-in-script&sq=&callback=Tabletop.singleton.loadSheet"
+  sheet_url = "https://spreadsheets.google.com/feeds/list/#{key}/#{sheet_id}/public/values?alt=json-in-script#{sq}&callback=Tabletop.singleton.loadSheet"
   content = open(sheet_url).read
-  File.open("#{key}-#{sheet_id}", 'w') { |f| f.write(content) } 
+  File.open("#{key}-#{sheet_id}", 'w') { |f| f.write(content) }
 end
 
-File.open("#{key}", 'w') { |f| f.write(base_json_content) } 
+File.open("#{key}", 'w') { |f| f.write(base_json_content) }


### PR DESCRIPTION
I noticed the scripts in `caching/` didn't work with the new version of Sheets as per #67. I've thus added an "--old" flag to each of them, which conditionally inserts the `sq=` get argument depending on whether Google Spreadsheets or Google Sheets is being used (defaults to the new version).
