### PR TITLE
Lints code; adds a very permissive .jshintrc.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,8 +7,8 @@
 
     // Enforcing
     "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
-    "camelcase"     : false,    // true: Identifiers must be in camelCase
-    "curly"         : false,     // true: Require {} for every new block or scope
+    "camelcase"     : true,    // true: Identifiers must be in camelCase
+    "curly"         : true,     // true: Require {} for every new block or scope
     "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
     "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
     "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
@@ -21,7 +21,7 @@
     "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
     "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
     "plusplus"      : false,    // true: Prohibit use of `++` & `--`
-    "quotmark"      : false,    // Quotation mark consistency:
+    "quotmark"      : "single",    // Quotation mark consistency:
                                 //   false    : do nothing (default)
                                 //   true     : ensure whatever is used is consistent
                                 //   "single" : require single quotes

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,98 @@
+{
+    // JSHint Configuration File
+    // Via https://github.com/jshint/jshint/blob/master/examples/.jshintrc
+    // See http://jshint.com/docs/ for more details
+
+    "maxerr"        : 50,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : false,    // true: Identifiers must be in camelCase
+    "curly"         : false,     // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+    "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "indent"        : 2,        // {int} Number of spaces to use for indentation
+    "latedef"       : false,    // true: Require variables/functions to be defined before being used
+    "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
+    "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
+    "quotmark"      : false,    // Quotation mark consistency:
+                                //   false    : do nothing (default)
+                                //   true     : ensure whatever is used is consistent
+                                //   "single" : require single quotes
+                                //   "double" : require double quotes
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : true,     // Unused variables:
+                                //   true     : all variables, last function parameter
+                                //   "vars"   : all variables only
+                                //   "strict" : all variables, all function parameters
+    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+    "maxparams"     : false,    // {int} Max number of formal params allowed per function
+    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : false,    // {int} Max number statements per function
+    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : false,    // {int} Max number of characters per line
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
+    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+                                 // (ex: `for each`, multiple try/catch, function expression…)
+    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements
+    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : false,     // true: Tolerate multi-line strings
+    "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
+    "notypeof"      : false,     // true: Tolerate invalid typeof operator values
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+    // Environments
+    "browser"       : true,     // Web Browser (window, document, etc)
+    "browserify"    : false,    // Browserify (node.js code in the browser)
+    "couch"         : false,    // CouchDB
+    "devel"         : true,     // Development/debugging (alert, confirm, etc)
+    "dojo"          : false,    // Dojo Toolkit
+    "jasmine"       : false,    // Jasmine
+    "jquery"        : false,    // jQuery
+    "mocha"         : true,     // Mocha
+    "mootools"      : false,    // MooTools
+    "node"          : true,    // Node.js
+    "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
+    "phantom"       : false,    // PhantomJS
+    "prototypejs"   : false,    // Prototype and Scriptaculous
+    "qunit"         : false,    // QUnit
+    "rhino"         : false,    // Rhino
+    "shelljs"       : false,    // ShellJS
+    "typed"         : false,    // Globals for typed array constructions
+    "worker"        : false,    // Web Workers
+    "wsh"           : false,    // Windows Scripting Host
+    "yui"           : false,    // Yahoo User Interface
+
+    // Custom Globals
+    "globals"       : {
+      "define": true, // For AMD in tabletop.js
+      "Backbone": true, // For backbone.tabletopSync.js
+      "Tabletop": true, // Same.
+      "_": true // Ditto
+    }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,23 +1,43 @@
+"use strict";
 module.exports = function(grunt) {
+  grunt.loadNpmTasks("grunt-contrib-connect");
+  grunt.loadNpmTasks("grunt-contrib-jshint");
 
-    grunt.loadNpmTasks("grunt-contrib-connect");
-
-    grunt.initConfig({
-        connect: {
-            testing: {
-                options: {
-                    port: 8080
-                }
-            },
-            secure: {
-                options: {
-                    port: 8081,
-                    keepalive: true,
-                    protocol: "https"
-                }
-            }
+  grunt.initConfig({
+    connect: {
+      testing: {
+        options: {
+          port: 8080
         }
-    });
+      },
+      secure: {
+        options: {
+          port: 8081,
+          keepalive: true,
+          protocol: "https"
+        }
+      }
+    },
+    // Make sure code styles are up to par and there are no obvious mistakes
+    jshint: {
+      options: {
+        jshintrc: '.jshintrc',
+        reporter: require('jshint-stylish')
+      },
+      all: {
+        src: [
+          'Gruntfile.js',
+          'src/{,*/}*.js'
+        ]
+      },
+      // test: { // TODO re-enable once unit tests are done.
+      //   options: {
+      //     jshintrc: 'test/.jshintrc'
+      //   },
+      //   src: ['test/spec/{,*/}*.js']
+      // }
+    }
+  });
 
-    grunt.registerTask("default", ["connect"]);
-}
+  grunt.registerTask("default", ["jshint", "connect"]);
+};

--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "devDependencies": {
+    "grunt-contrib-jshint": "^0.11.2",
+    "jshint-stylish": "^2.0.0"
   }
 }

--- a/src/backbone.tabletopSync.js
+++ b/src/backbone.tabletopSync.js
@@ -5,11 +5,14 @@
 
   Backbone.tabletopSync only supports the 'read' method, and will fail
     loudly on any other operations
+    
 */
+
+'use strict';
 
 Backbone.tabletopSync = function(method, model, options, error) {
   // Backwards compatibility with Backbone <= 0.3.3
-  if (typeof options == 'function') {
+  if (typeof options === 'function') {
     options = {
       success: options,
       error: error
@@ -22,16 +25,16 @@ Backbone.tabletopSync = function(method, model, options, error) {
 
   var instance = tabletopOptions.instance;
 
-  if(typeof(instance) == "undefined") {
+  if(typeof(instance) === "undefined") {
     instance = Tabletop.init( { key: tabletopOptions.key,
                                 wanted: [ tabletopOptions.sheet ],
-                                wait: true } )
+                                wait: true } );
     tabletopOptions.instance = instance;
   } else {
     instance.addWanted(tabletopOptions.sheet);
   }
   
-  if(typeof(tabletopOptions.sheet) == "undefined") {
+  if(typeof(tabletopOptions.sheet) === "undefined") {
     return;
   }
   
@@ -47,7 +50,7 @@ Backbone.tabletopSync = function(method, model, options, error) {
 
     instance.fetch( function() {
       Backbone.tabletopSync(method, model, options, error);
-    })
+    });
     return;
   }
   
@@ -55,7 +58,7 @@ Backbone.tabletopSync = function(method, model, options, error) {
     case "read":
       if(model.id) {
         resp = _.find( sheet.all(), function(item) {
-          return model.id == item[model.idAttribute];
+          return model.id === item[model.idAttribute];
         }, this);
       } else {
         resp = sheet.all();

--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -70,7 +70,7 @@
     this.simple_url = !!options.simple_url;
     this.callbackContext = options.callbackContext;
     // Default to on, unless there's a proxy, in which case it's default off
-    this.prettyColumnNames = typeof(options.prettyColumnNames) == 'undefined' ? !options.proxy : options.prettyColumnNames
+    this.prettyColumnNames = typeof(options.prettyColumnNames) === 'undefined' ? !options.proxy : options.prettyColumnNames;
     
     if(typeof(options.proxy) !== 'undefined') {
       // Remove trailing slash, it will break the app
@@ -175,8 +175,9 @@
       xhr.open("GET", this.endpoint + path);
       var self = this;
       xhr.onload = function() {
+        var json;
         try {
-          var json = JSON.parse(xhr.responseText);
+          json = JSON.parse(xhr.responseText);
         } catch (e) {
           console.error(e);
         }
@@ -241,7 +242,7 @@
       This will only run if tabletop is being run in node.js
     */
     serverSideFetch: function(path, callback) {
-      var self = this
+      var self = this;
       request({url: this.endpoint + path, json: true}, function(err, resp, body) {
         if (err) {
           return console.error(err);
@@ -312,7 +313,7 @@
         if( this.isWanted(data.feed.entry[i].content.$t) ) {
           var linkIdx = data.feed.entry[i].link.length-1;
           var sheet_id = data.feed.entry[i].link[linkIdx].href.split('/').pop();
-          var json_path = "/feeds/list/" + this.key + "/" + sheet_id + "/public/values?alt="
+          var json_path = "/feeds/list/" + this.key + "/" + sheet_id + "/public/values?alt=";
           if (inNodeJS || supportsCORS) {
             json_path += 'json';
           } else {
@@ -373,7 +374,7 @@
     */
     loadSheet: function(data) {
       var that = this;
-      var model = new Tabletop.Model( { data: data, 
+      new Tabletop.Model( { data: data, 
                                         parseNumbers: this.parseNumbers,
                                         postProcess: this.postProcess,
                                         tabletop: this,
@@ -394,7 +395,7 @@
       }
     },
 
-    log: function(msg) {
+    log: function() {
       if(this.debug) {
         if(typeof console !== "undefined" && typeof console.log !== "undefined") {
           Function.prototype.apply.apply(console.log, [console, arguments]);
@@ -437,7 +438,7 @@
     for(i = 0, ilen =  options.data.feed.entry.length ; i < ilen; i++) {
       var source = options.data.feed.entry[i];
       var element = {};
-      for(var j = 0, jlen = this.column_names.length; j < jlen ; j++) {
+      for(j = 0, jlen = this.column_names.length; j < jlen ; j++) {
         var cell = source[ "gsx$" + this.column_names[j] ];
         if (typeof(cell) !== 'undefined') {
           if(options.parseNumbers && cell.$t !== '' && !isNaN(cell.$t))
@@ -475,7 +476,7 @@
       var cellurl = this.raw.feed.link[3].href.replace('/feeds/list/', '/feeds/cells/').replace('https://spreadsheets.google.com', '');
       var that = this;
       this.tabletop.requestData(cellurl, function(data) {
-        that.loadPrettyColumns(data)
+        that.loadPrettyColumns(data);
       });
     },
     
@@ -520,7 +521,6 @@
           ordered_pretty_names = [],
           i, j, ilen, jlen;
 
-      var ordered_pretty_names;
       for(j = 0, jlen = this.column_names.length; j < jlen ; j++) {
         ordered_pretty_names.push(this.pretty_columns[this.column_names[j]]);
       }


### PR DESCRIPTION
I've linted Tabletop and added a very basic and permissive .jshintrc. Note that I've done a few things that I worry will break other things (though am 98% sure they won't); please don't merge this until after I do my unit test PR so I can ensure I've not added any regressive bugs. Thanks!

Notes:
- I've turned off the "camelcase" and "curly" options because I didn't want to change @jsoma's code style any more than I have to. Also, because camelcasing `simple_url`, `model_names`, `column_names`, `original_columns` and `pretty_columns` would break backwards compatibility.
-  That all said, it wouldn't be the worst idea to change these all to camelcase if ever a Tabletop 2.x version is released given that the API is fairly inconsistent with regards to its use of camel/snake case.
- I removed the named argument from `log()` as it's unused (the "arguments" object is passed in to console.log instead). I don't think that would have any impact, but again, want to ensure with unit tests before this is merged.
- In `loadSheet()` I removed the variable association on ln. 377 because it was never used — everything is passed to the callback AFAIK, so it doesn't need to be stored in a variable. Again though, want to ensure that doesn't break anything.
- Beyond that I added a bunch of semicolons and changed all instances of `==` to `===`.
