### PR TITLE
Fix Browserify+Babel issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,9 @@
   "readmeFilename": "README.md",
   "gitHead": "fdb1c3ee3bc0f7f3be6ab223a56f9f050fe32496",
   "dependencies": {
-    "browser-request": "^0.3.3",
     "grunt": "*",
     "grunt-contrib-connect": "*",
     "request": "~2.51.0"
-  },
-  "browser": {
-    "request": "browser-request"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -1,10 +1,10 @@
-(function(global) {
+(function() {
   "use strict";
 
   var inNodeJS = false;
-  if (typeof module !== 'undefined' && module.exports) {
+  if (typeof process !== undefined && !process.browser) {
     inNodeJS = true;
-    var request = require('request');
+    var request = require('request'.trim()); //prevents browserify from bundling the module
   }
 
   var supportsCORS = false;
@@ -554,14 +554,14 @@
     }
   };
 
-  if(inNodeJS) {
+  if(typeof module !== "undefined" && module.exports) { //don't just use inNodeJS, we may be in Browserify
     module.exports = Tabletop;
   } else if (typeof define === 'function' && define.amd) {
     define(function () {
         return Tabletop;
     });
   } else {
-    global.Tabletop = Tabletop;
+    window.Tabletop = Tabletop;
   }
 
-})(this);
+})();


### PR DESCRIPTION
There are two separate issues being fixed here: `inNodeJS` is useful for request logic, but
shouldn't be used to determine how we export Tabletop, since Browserify
still uses module.exports. I eliminated the `global` variable, since it causes failure when coupled with Babel (which rewrites its modules into strict mode).

Second, Browserify will happily bundle 1.5MB of extra stuff we don't
need if we use the `browser-request module`, even though we have our own
well-tested AJAX code. So we need to prevent its static `require`
analyzer from seeing the module load, while still letting this work in
Node itself. `trim()` seems like a simple enough way to do this, without
having to include browser-specific packaging (in other words, rather
than shim it, just don't actually require anything).

After this fix, the bundled JavaScript size dropped to about 30KB, which seems normal, and it was still exported correctly for Browserify.