### PR TITLE
Upgrade vulnerable `request` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # **Tabletop.js** (gives spreadsheets legs)
 
+[![Known Vulnerabilities](https://snyk.io/test/github/jsoma/tabletop/badge.svg)](https://snyk.io/test/github/jsoma/tabletop)
+
 **Tabletop.js** takes a Google Spreadsheet and makes it easily accessible through JavaScript. With zero dependencies! If you've ever wanted to get JSON from a Google Spreadsheet without jumping through a thousand hoops, welcome home.
 
 Tabletop.js easily integrates Google Spreadsheets with Backbone.js, Handlebars, and anything else that is hip and cool. It will also help you make new friends and play jazz piano.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "examples"
   },
   "scripts": {
-    "test": "node examples/nodejs/test.js"
+    "test": "snyk test && node examples/nodejs/test.js"
   },
   "repository": {
     "type": "git",
@@ -20,7 +20,10 @@
   "dependencies": {
     "grunt": "*",
     "grunt-contrib-connect": "*",
-    "request": "~2.51.0"
+    "request": "^2.68.0"
+  },
+  "devDependencies": {
+    "snyk": "^1.13.3"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
`tabletop` currently uses a vulnerable version of `request`, which also pulls in a vulnerable version of `hawk`.
You can see details here (note this points to the latest commit hash at the time of this PR): https://snyk.io/test/github/jsoma/tabletop/944fc159761e3580351eb4a8cc091d2be47e1d04

This PR upgrades `request` to the minimal version that isn't vulnerable. 
This includes no major upgrades, so should have no disruption.

I also added `snyk test` to the test process, to help the project stay vulnerability free (will fail the test if new vulns are introduced). I recommend you also monitor the project by running [`snyk wizard`](https://snyk.io/docs/using-snyk/#wizard), doing so will alert you when a new vulnerability that affects your dependencies is disclosed.

Lastly, to show the world you're doing a good job on security (and that they should care), I took the liberty of adding a badge stating you're free of known vulnerabilities. If you're gonna be awesome, no reason to hide it!
Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
