### PR TITLE
Return XHR status error codes as err param.

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -190,13 +190,20 @@
       xhr.open('GET', this.endpoint + path);
       var self = this;
       xhr.onload = function() {
+       /*
+         Return early with Node-style err parameter in case of XHR error.
+       */
+        if(xhr.status >= 400) {
+          return self.callback.call(self, xhr.status)
+        }
+        
         var json;
         try {
           json = JSON.parse(xhr.responseText);
         } catch (e) {
           console.error(e);
         }
-        callback.call(self, json);
+        callback.call(self, null, json);
       };
       xhr.send();
     },
@@ -415,7 +422,7 @@
     */
     doCallback: function() {
       if(this.sheetsToLoad === 0) {
-        this.callback.apply(this.callbackContext || this, [this.data(), this]);
+        this.callback.apply(this.callbackContext || this, [null, this.data(), this]);
       }
     },
 


### PR DESCRIPTION
XHR status codes, 400 or over, are returned as Node-style err param.