### PR TITLE
Minor fixup to suppress a warning in Webpack

### DIFF
--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -1,10 +1,13 @@
 (function() {
   'use strict';
 
-  var inNodeJS = false;
-  if (typeof process !== 'undefined' && !process.browser) {
-    inNodeJS = true;
-    var request = require('request'.trim()); //prevents browserify from bundling the module
+  var inNodeJS = typeof process !== 'undefined' && !process.browser;
+
+  var request = function requestNotProvided() {
+    throw new Error("The 'request' module is only available while running in Node.");
+  };
+  if(inNodeJS) { // This will get stripped out by Uglify, and Webpack will not include it
+    request = require('request');
   }
 
   var supportsCORS = false;
@@ -22,7 +25,7 @@
   } catch (e) { }
 
   // Create a simple indexOf function for support
-  // of older browsers.  Uses native indexOf if 
+  // of older browsers.  Uses native indexOf if
   // available.  Code similar to underscores.
   // By making a separate function, instead of adding
   // to the prototype, we will not break bad for loops
@@ -30,11 +33,11 @@
   var indexOfProto = Array.prototype.indexOf;
   var ttIndexOf = function(array, item) {
     var i = 0, l = array.length;
-    
+
     if (indexOfProto && array.indexOf === indexOfProto) {
       return array.indexOf(item);
     }
-    
+
     for (; i < l; i++) {
       if (array[i] === item) {
         return i;
@@ -42,7 +45,7 @@
     }
     return -1;
   };
-  
+
   /*
     Initialize with Tabletop.init( { key: '0AjAPaAU9MeLFdHUxTlJiVVRYNGRJQnRmSnQwTlpoUXc' } )
       OR!
@@ -56,7 +59,7 @@
     if(!this || !(this instanceof Tabletop)) {
       return new Tabletop(options);
     }
-    
+
     if(typeof(options) === 'string') {
       options = { key : options };
     }
@@ -78,7 +81,7 @@
     this.callbackContext = options.callbackContext;
     // Default to on, unless there's a proxy, in which case it's default off
     this.prettyColumnNames = typeof(options.prettyColumnNames) === 'undefined' ? !options.proxy : options.prettyColumnNames;
-    
+
     if(typeof(options.proxy) !== 'undefined') {
       // Remove trailing slash, it will break the app
       this.endpoint = options.proxy.replace(/\/$/,'');
@@ -88,16 +91,16 @@
       // fetching straight from Google
       supportsCORS = false;
     }
-    
+
     this.parameterize = options.parameterize || false;
-    
+
     if (this.singleton) {
       if (typeof(Tabletop.singleton) !== 'undefined') {
         this.log('WARNING! Tabletop singleton already defined');
       }
       Tabletop.singleton = this;
     }
-    
+
     /* Be friendly about what you accept */
     if (/key=/.test(this.key)) {
       this.log('You passed an old Google Docs url as the key! Attempting to parse.');
@@ -108,7 +111,7 @@
       this.log('You passed a new Google Spreadsheets url as the key! Attempting to parse.');
       this.key = this.key.match('d\\/(.*?)\\/pubhtml')[1];
     }
-    
+
     if(/spreadsheets\/d/.test(this.key)) {
       this.log('You passed the most recent version of Google Spreadsheets url as the key! Attempting to parse.');
       this.key = this.key.match('d\\/(.*?)\/')[1];
@@ -132,7 +135,7 @@
     } else {
       this.baseJsonPath += 'json-in-script';
     }
-    
+
     if(!this.wait) {
       this.fetch();
     }
@@ -158,10 +161,10 @@
       }
       this.requestData(this.baseJsonPath, this.loadSheets);
     },
-    
+
     /*
       This will call the environment appropriate request method.
-      
+
       In browser it will use JSON-P, in node it will use request()
     */
     requestData: function(path, callback) {
@@ -200,7 +203,7 @@
       };
       xhr.send();
     },
-    
+
     /*
       Insert the URL into the page as a script tag. Once it's loaded the spreadsheet data
       it triggers the callback. This helps you avoid cross-domain errors
@@ -211,7 +214,7 @@
     injectScript: function(path, callback) {
       var script = document.createElement('script');
       var callbackName;
-      
+
       if (this.singleton) {
         if (callback === this.loadSheets) {
           callbackName = 'Tabletop.singleton.loadSheets';
@@ -231,9 +234,9 @@
         };
         callbackName = 'Tabletop.callbacks.' + callbackName;
       }
-      
+
       var url = path + '&callback=' + callbackName;
-      
+
       if (this.simpleUrl) {
         // We've gone down a rabbit hole of passing injectScript the path, so let's
         // just pull the sheet_id out of the path like the least efficient worker bees
@@ -245,7 +248,7 @@
       } else {
         script.src = this.endpoint + url;
       }
-      
+
       if (this.parameterize) {
         script.src = this.parameterize + encodeURIComponent(script.src);
       }
@@ -254,8 +257,8 @@
 
       document.getElementsByTagName('script')[0].parentNode.appendChild(script);
     },
-    
-    /* 
+
+    /*
       This will only run if tabletop is being run in node.js
     */
     serverSideFetch: function(path, callback) {
@@ -270,7 +273,7 @@
       });
     },
 
-    /* 
+    /*
       Is this a sheet you want to pull?
       If { wanted: ["Sheet1"] } has been specified, only Sheet1 is imported
       Pulls all sheets if none are specified
@@ -282,7 +285,7 @@
         return (ttIndexOf(this.wanted, sheetName) !== -1);
       }
     },
-    
+
     /*
       What gets send to the callback
       if simpleSheet === true, then don't return an array of Tabletop.this.models,
@@ -312,7 +315,7 @@
         this.wanted.push(sheet);
       }
     },
-    
+
     /*
       Load all worksheets of the spreadsheet, turning each into a Tabletop Model.
       Need to use injectScript because the worksheet view that you're working from
@@ -382,13 +385,13 @@
       if (ttIndexOf(this.modelNames, model.name) === -1) {
         this.modelNames.push(model.name);
       }
-      
+
       this.sheetsToLoad--;
       if (this.sheetsToLoad === 0) {
         this.doCallback();
       }
     },
-    
+
     /*
       Parse a single list-based worksheet, turning it into a Tabletop Model
 
@@ -396,15 +399,15 @@
     */
     loadSheet: function(data) {
       var that = this;
-      new Tabletop.Model({ 
-        data: data, 
+      new Tabletop.Model({
+        data: data,
         parseNumbers: this.parseNumbers,
         postProcess: this.postProcess,
         tabletop: this,
         prettyColumnNames: this.prettyColumnNames,
         onReady: function() {
           that.sheetReady(this);
-        } 
+        }
       });
     },
 
@@ -452,7 +455,7 @@
       this.onReady.call(this);
       return;
     }
-    
+
     for (var key in options.data.feed.entry[0]){
       if (/^gsx/.test(key)) {
         this.columnNames.push(key.replace('gsx$',''));
@@ -461,7 +464,7 @@
 
     this.originalColumns = this.columnNames;
     this.original_columns = this.originalColumns; // jshint ignore:line
-    
+
     for (i = 0, ilen =  options.data.feed.entry.length ; i < ilen; i++) {
       var source = options.data.feed.entry[i];
       var element = {};
@@ -480,14 +483,14 @@
       if (element.rowNumber === undefined) {
         element.rowNumber = i + 1;
       }
-        
+
       if (options.postProcess) {
         options.postProcess(element);
       }
-        
+
       this.elements.push(element);
     }
-    
+
     if (options.prettyColumnNames) {
       this.fetchPrettyColumns();
     } else {
@@ -502,23 +505,23 @@
     all: function() {
       return this.elements;
     },
-    
+
     fetchPrettyColumns: function() {
       if (!this.raw.feed.link[3]) {
         return this.ready();
       }
-        
+
       var cellurl = this.raw.feed.link[3].href.replace('/feeds/list/', '/feeds/cells/').replace('https://spreadsheets.google.com', '');
       var that = this;
       this.tabletop.requestData(cellurl, function(data) {
         that.loadPrettyColumns(data);
       });
     },
-    
+
     ready: function() {
       this.onReady.call(this);
     },
-    
+
     /*
      * Store column names as an object
      * with keys of Google-formatted "columnName"
@@ -545,7 +548,7 @@
       this.prettifyElements();
       this.ready();
     },
-    
+
     /*
      * Go through each row, substitutiting
      * Google-formatted "columnName"
@@ -585,7 +588,7 @@
         }
         array.push(row);
       }
-      
+
       return array;
     }
   };


### PR DESCRIPTION
Aside from removing garbage whitespace (sorry, vim does it for me!), this PR fixes a really loud and obnoxious warning in Webpack, since it is incapable of walking the `require('request'.trim())`. Webpack, at least, is smart enough to get rid of the unused module. Presumably Browserify is, as well.  If not, then you can pull a trick like this: http://stackoverflow.com/a/23239633 -- the consumer of the app could even make `request` point to an empty file, or have it export an error message, if they really cared.