### PR TITLE
Http proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ For example:
 
 `proxy` allows you to easily use spreadsheets not located on Google Spreadsheet servers. Setting `proxy: "http://www.proxy.com"` is equivalent to setting `{ simple_url: true, singleton: true, endpoint: "http://www.proxy.com" }`. [Flatware](https://github.com/jsoma/flatware) might provide better documentation.
 
+
+#### httpProxyUrl
+
+`httpProxyUrl` if tabletop is being used in a node.js environment and httpProxyUrl is provided, Tabletop will pass the proxy url as the proxy argument to the JS request module, e.g.  `httpProxyUrl: "http:uname:pw@proxy:port"`
+
 #### wait
 
 `wait` prevents tabletop from pulling the Google spreadsheet until you're ready. Used in the backbone.js example.

--- a/src/tabletop.js
+++ b/src/tabletop.js
@@ -80,6 +80,7 @@
     this.simpleUrl = !!(options.simpleUrl || options.simple_url); //jshint ignore:line
     this.authkey = options.authkey;
     this.sheetPrivacy = this.authkey ? 'private' : 'public'
+    this.httpProxyUrl = option.httpProxyUrl;
 
     this.callbackContext = options.callbackContext;
     // Default to on, unless there's a proxy, in which case it's default off
@@ -268,7 +269,15 @@
       var self = this;
 
       this.log('Fetching', this.endpoint + path);
-      request({url: this.endpoint + path, json: true}, function(err, resp, body) {
+      var requestOpts = {};
+      typeof(this.httpProxyUrl) === 'undefined'
+        ? (requestOpts = { url: this.endpoint + path, json: true })
+        : (requestOpts = {
+            url: this.endpoint + path,
+            json: true,
+            proxy: this.httpProxyUrl,
+          });
+      request(requestOpts, function(err, resp, body) {
         if (err) {
           return console.error(err);
         }


### PR DESCRIPTION
Quick fix for node.js server using tabletop running behind a corporate proxy.
Providing the httpProxyUrl option will enable the node.js server to resolve the request through the proxy.

E.g.
```javascript
Tabletop.init({
    key: "key",
    callback: function = (data, tabletop) => {console.log(data)},
    httpProxyUrl: "http://username:password@proxy:proxyport",
  });
```

