### PR TITLE
Add missing parenthesis in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ function init() {
 
  function showInfo(data, tabletop) {
   // do something with the data
-  console.log(JSON.stringify(data, null, 2);
+  console.log(JSON.stringify(data, null, 2));
 }
 
 //initialise and kickstart the whole thing.


### PR DESCRIPTION
There is a parenthesis missing in one part of the example code in the Readme.